### PR TITLE
in function connectWS, sub.resourcePath instead of sub.resource_path

### DIFF
--- a/api/QueryAPI.js
+++ b/api/QueryAPI.js
@@ -472,7 +472,7 @@ function QueryAPI (port, storeFn, serviceName, pri, modifyEvents, iface) {
            duration : { numerator: 0, denominator: 1 },
            grain : {
              type : "urn:x-nmos:format:data.event",
-             topic : `${sub.resourcePath}/`,
+             topic : `${sub.resource_path}/`,
              data : resources.map(function (ro) {
                return { path : ro.id, pre : ro, post : ro };
              })


### PR DESCRIPTION
just a typo leading to sending a topic as "undefined/" when a websocket client connect to a subscription.